### PR TITLE
fix hardhat.config.js for automated test

### DIFF
--- a/packages/contract/hardhat.config.js
+++ b/packages/contract/hardhat.config.js
@@ -5,8 +5,14 @@ module.exports = {
   solidity: '0.8.17',
   networks: {
     goerli: {
-      url: process.env.STAGING_ALCHEMY_KEY,
-      accounts: [process.env.PRIVATE_KEY],
+      url:
+        typeof process.env.STAGING_ALCHEMY_KEY === 'undefined'
+          ? ''
+          : process.env.STAGING_ALCHEMY_KEY,
+      accounts:
+        typeof process.env.PRIVATE_KEY === 'undefined'
+          ? ['0'.repeat(64)]
+          : [process.env.PRIVATE_KEY],
     },
     // mainnet: {
     //   chainId: 1,

--- a/packages/contract/hardhat.config.js
+++ b/packages/contract/hardhat.config.js
@@ -1,18 +1,14 @@
 require('@nomicfoundation/hardhat-toolbox');
 require('dotenv').config();
 
+const { PRIVATE_KEY, STAGING_ALCHEMY_KEY } = process.env;
+
 module.exports = {
   solidity: '0.8.17',
   networks: {
     goerli: {
-      url:
-        typeof process.env.STAGING_ALCHEMY_KEY === 'undefined'
-          ? ''
-          : process.env.STAGING_ALCHEMY_KEY,
-      accounts:
-        typeof process.env.PRIVATE_KEY === 'undefined'
-          ? ['0'.repeat(64)]
-          : [process.env.PRIVATE_KEY],
+      url: STAGING_ALCHEMY_KEY || '',
+      accounts: PRIVATE_KEY ? [PRIVATE_KEY] : ['0'.repeat(64)],
     },
     // mainnet: {
     //   chainId: 1,


### PR DESCRIPTION
hardhat.config.jsにおいて環境変数を使用していることが自動テストにおけるエラーの原因になっていた。そこで.envファイルが存在していない場合でもテストが動くように調整。